### PR TITLE
Updated aws-sdk to version 2.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/fhemberger/catbox-s3",
   "dependencies": {
-    "aws-sdk": "2.2.4",
+    "aws-sdk": "2.2.6",
     "hoek": "2.16.3",
     "request": "2.64.0"
   },


### PR DESCRIPTION
:rocket:

aws-sdk just published version 2.2.6, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 31 commits (ahead by 31, behind by 0).

- [70d2f08](https://github.com/aws/aws-sdk-js/commit/70d2f084f432fcbff0b774476d76a4a8d0cee8cb): Tag release v2.2.6
- [4fb3fb1](https://github.com/aws/aws-sdk-js/commit/4fb3fb178e5076bcf57b85ab107a7949ffe127cb): Update AWS.WorkSpaces API
- [19fff16](https://github.com/aws/aws-sdk-js/commit/19fff16aebee1b51b4c9ce0da9825767ad302f5a): Update AWS.RDS API
- [564fc89](https://github.com/aws/aws-sdk-js/commit/564fc899ed322f51e76a438418b2dff59e9ce81d): Update CloudTrail API
- [0abf9d4](https://github.com/aws/aws-sdk-js/commit/0abf9d47b0ea1fbfa93c6dab0c2005466577001e): Update AWS.ES API
- [2bd4bc3](https://github.com/aws/aws-sdk-js/commit/2bd4bc3a5ebfecb08ded88798dc480e08a91a1b3): Merge pull request #742 from aws/fix/managed-upload-location
- [53459b2](https://github.com/aws/aws-sdk-js/commit/53459b2f937c22b2a93d9c5f3ceaa48f4d6bee5f): Fix data.location duplication for AWS.S3.ManagedUpload
- [82aac9a](https://github.com/aws/aws-sdk-js/commit/82aac9a576bf8395c09502fad1f7c4df782ebe8c): Merge pull request #726 from aws/fix/doc-client-paginators
- [21a5bf2](https://github.com/aws/aws-sdk-js/commit/21a5bf239c6462373be5d262a85b6963989040a6): Tag release v2.2.5
- [f48d1bd](https://github.com/aws/aws-sdk-js/commit/f48d1bd9c598cb1db746de1b9a9e1926b6c38578): Updated ec2 unit tests
- [b8f08bb](https://github.com/aws/aws-sdk-js/commit/b8f08bb0b370704b0cde41d2a039b1d2e953251b): Update AWS.CloudFormation API
- [2ea7cd0](https://github.com/aws/aws-sdk-js/commit/2ea7cd07e06c2884bac8de4bc75f312d45606bf2): Update AWS.EC2 API
- [a9013e3](https://github.com/aws/aws-sdk-js/commit/a9013e357abe9d0a6962bde5e7450210d29005b0): Update AWS.SES API
- [38c07f2](https://github.com/aws/aws-sdk-js/commit/38c07f23c1171a1ba029c8dea8dfb9d5df2d3441): Add tests for nextPage override.
- [a012fb5](https://github.com/aws/aws-sdk-js/commit/a012fb585198471bbcb74a36828ef7caaea6b0dc): Merge pull request #739 from aws/add/support-for-query-string-maps


There are 31 commits in total. See the [full diff](https://github.com/aws/aws-sdk-js/compare/17a6cc5f55e84b7b162956c1f48f3c8b62139764...70d2f084f432fcbff0b774476d76a4a8d0cee8cb).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>