### PR TITLE
Make catbox-s3 compatible with other S3 APIs besides the one from Amazon

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Amazon S3 adapter for [catbox](https://github.com/hapijs/catbox).
 - `accessKeyId` - the Amazon access key.
 - `secretAccessKey` - the Amazon secret access key.
 - `region` - the Amazon S3 region. (If you don't specify a region, the bucket will be created in US Standard.)
+- `endpoint` - the S3 endpoint URL. (If you don't specify an endpoint, the bucket will be created at Amazon S3 using the provided region if any)
+- `setACL` - defaults to true, if set to false, not acl is set for the objects
+- `ACL` - the ACL to set if setACL is not false, defaults to `public-read`
 
 
 ### Caching binary data
@@ -25,7 +28,7 @@ var Catbox = require('catbox');
 var cache  = new Catbox.Client(require('catbox-s3'), {
     accessKeyId     : /* ... */,
     secretAccessKey : /* ... */,
-    region          : /* ... */,
+    region          : /* ... (optional) */,
     bucket          : /* ... */
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 // Load modules
-const Wreck = require('wreck');
 const Hoek = require('hoek');
 const AWS  = require('aws-sdk');
 
@@ -33,13 +32,13 @@ internals.getStoragePathForKey = function (key) {
 };
 
 
-internals.parseBody = function (res, body) {
+internals.parseBody = function (contentType, body) {
 
-    if (res.headers['content-type'] === 'text/plain' && Buffer.isBuffer(body)) {
+    if (contentType === 'text/plain' && Buffer.isBuffer(body)) {
         body = body.toString();
     }
 
-    if (res.headers['content-type'] === 'application/json') {
+    if (contentType === 'application/json') {
         /* eslint-disable brace-style */
         try {
             body = JSON.parse(body);
@@ -51,27 +50,32 @@ internals.parseBody = function (res, body) {
 };
 
 
-internals.testBucketAccess = function (client, bucket, callback) {
+internals.testBucketAccess = function (client, settings, callback) {
 
-    const putParams = {
-        Bucket : bucket,
+    /* eslint-disable prefer-const */
+    let putParams = {
+        Bucket : settings.bucket,
         Key    : internals.getStoragePathForKey({ segment: 'catbox-s3', id: 'accesstest' }),
-        ACL    : 'public-read',
         Body   : 'ok'
     };
+    /* eslint-enable prefer-const */
+
+    if (settings.setACL !== false) {
+        putParams.ACL = settings.ACL ? settings.ACL : 'public-read';
+    }
 
     const getParams = {
-        Bucket : bucket,
+        Bucket : settings.bucket,
         Key    : internals.getStoragePathForKey({ segment: 'catbox-s3', id: 'accesstest' })
     };
 
     client.putObject(putParams, (err) => {
 
-        Hoek.assert(!err, `Error writing to bucket ${bucket}`);
+        Hoek.assert(!err, `Error writing to bucket ${settings.bucket} ${err}`);
 
         client.getObject(getParams, (err, data) => {
 
-            Hoek.assert(!err && data.Body.toString('utf8') === 'ok', `Error reading from bucket ${bucket}`);
+            Hoek.assert(!err && data.Body.toString('utf8') === 'ok', `Error reading from bucket ${settings.bucket} ${err}`);
             callback();
         });
     });
@@ -103,9 +107,13 @@ internals.Connection.prototype.start = function (callback) {
         clientOptions.region = this.settings.region;
     }
 
+    if (this.settings.endpoint) {
+        clientOptions.endpoint = this.settings.endpoint;
+    }
+
     this.client = new AWS.S3(clientOptions);
 
-    internals.testBucketAccess(this.client, this.settings.bucket, (err, data) => {
+    internals.testBucketAccess(this.client, this.settings, (err, data) => {
 
         if (err) {
             self.isConnected = false;
@@ -157,25 +165,20 @@ internals.Connection.prototype.get = function (key, callback) {
         return callback(new Error('Connection not started'));
     }
 
-    const baseUrl = this.settings.region ?
-        `http://s3-${this.settings.region}.amazonaws.com/` :
-        'http://s3.amazonaws.com/';
+    const params = {
+        Bucket      : this.settings.bucket,
+        Key         : internals.getStoragePathForKey(key),
+    };
 
-    const url = `${baseUrl}${this.settings.bucket}/${internals.getStoragePathForKey(key)}`;
-
-    Wreck.get(url, (err, res, body) => {
-
+    this.client.getObject(params, (err, data) => {
         if (err) {
-            return callback(err);
-        }
-
-        if (res.statusCode !== 200) {
             return callback(null, null);
         }
+        // console.log(data)
 
         const now    = new Date().getTime();
-        const stored = new Date(res.headers['x-amz-meta-catbox-stored']);
-        let ttl      = Number(res.headers['x-amz-meta-catbox-ttl']) || 0;
+        const stored = new Date(data.Metadata['catbox-stored']);
+        let ttl      = Number(data.Metadata['catbox-ttl']) || 0;
 
         // Calculate remaining ttl
         ttl = (stored.getTime() + ttl) - now;
@@ -185,13 +188,16 @@ internals.Connection.prototype.get = function (key, callback) {
             return callback(null, null);
         }
 
+        let body = data.Body.toString()
+
         const result = {
-            item   : internals.parseBody(res, body),
+            item   : internals.parseBody(data.ContentType, data.Body),
             stored : stored,
             ttl    : ttl
         };
 
         callback(null, result);
+
     });
 };
 
@@ -220,14 +226,19 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
     }
 
     const now = new Date();
-    const params = {
+    /* eslint-disable prefer-const */
+    let params = {
         Bucket      : this.settings.bucket,
         Key         : internals.getStoragePathForKey(key),
-        ACL         : 'public-read',
         Expires     : new Date(now.getTime() + ttl),
         ContentType : type,
         Body        : value
     };
+    /* eslint-disable prefer-const */
+
+    if (this.settings.setACL !== false) {
+        params.ACL = this.settings.ACL ? this.settings.ACL : 'public-read';
+    }
 
     const req = this.client.putObject(params);
     req.on('build', () => {
@@ -236,7 +247,6 @@ internals.Connection.prototype.set = function (key, value, ttl, callback) {
         req.httpRequest.headers['x-amz-meta-catbox-ttl']    = ttl;
     });
     req.send((err) => {
-
         if (err) {
             return callback(err);
         }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   "homepage": "https://github.com/fhemberger/catbox-s3",
   "dependencies": {
     "aws-sdk": "2.4.x",
-    "hoek": "4.x.x",
-    "wreck": "9.x.x"
+    "hoek": "4.x.x"
   },
   "devDependencies": {
     "catbox": "7.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -10,11 +10,16 @@ const S3 = require('..');
 const options = {
     accessKeyId     : process.env.S3_ACCESS_KEY,
     secretAccessKey : process.env.S3_SECRET_KEY,
-    bucket          : process.env.S3_BUCKET
+    bucket          : process.env.S3_BUCKET,
+    setACL          : process.env.S3_SET_ACL && process.env.S3_SET_ACL === 'false' ? false : true
 };
 
 if (process.env.S3_REGION) {
     options.region = process.env.S3_REGION;
+}
+
+if (process.env.S3_ENDPOINT) {
+    options.endpoint = process.env.S3_ENDPOINT;
 }
 
 
@@ -40,7 +45,6 @@ describe('S3', () => {
 
 
     it('creates a new connection', (done) => {
-
         const client = new Catbox.Client(S3, options);
         client.start((err) => {
 
@@ -49,7 +53,6 @@ describe('S3', () => {
             done();
         });
     });
-
 
     it('closes the connection', (done) => {
 


### PR DESCRIPTION
This adds the following configuration options:
- `endpoint`
- `setACL`
- `ACL`
as described in README.md

It maintains backwards compatibility.

These settings are required to be compatible with other S3 APIs besides Amazon. Tested against https://docs.developer.swisscom.com/service-offerings/dynamic.html

Let me know if I should change something in this PR. 