### PR TITLE
user option for specifying signatureVersion for server-encrypted buckets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,6 +109,10 @@ internals.Connection.prototype.start = function (callback) {
         clientOptions.endpoint = this.settings.endpoint;
     }
 
+    if (this.settings.signatureVersion) {
+        clientOptions.signatureVersion = this.settings.signatureVersion;
+    }
+
     this.client = new AWS.S3(clientOptions);
 
     internals.testBucketAccess(this.client, this.settings, (err, data) => {

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,10 @@ if (process.env.S3_ENDPOINT) {
     options.endpoint = process.env.S3_ENDPOINT;
 }
 
+if (process.env.S3_SIGNATURE_VERSION) {
+    options.signatureVersion = process.env.S3_SIGNATURE_VERSION;
+}
+
 
 // Test shortcuts
 const lab = exports.lab = Lab.script();


### PR DESCRIPTION
## Context

Our team owns a service that interacts with an S3 bucket that has Server Side Encryption enabled. In order for our service to interact with that S3 bucket, it needs to interact with KMS to be able to use the managed keys for encrypting & decrypting the objects. Depending on the encryption schema, it seems like AWS expects either a `v2` or `v4` parameter to use the correct signature version for interacting with KMS encrypted objects.

## Proposal

Allow the user the ability to specify the `signatureVersion` parameter for the S3 client.

## References:

* Thread showing the solution
   * https://forums.aws.amazon.com/thread.jspa?threadID=165286
* Other articles pointing out similar solutions:
   * https://github.com/aws/aws-sdk-core-ruby/issues/157
   * https://www.drupal.org/project/s3fs/issues/2876262