### PR TITLE
user option for forcing path-style URLs for S3 objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,10 @@ internals.Connection.prototype.start = function (callback) {
         clientOptions.signatureVersion = this.settings.signatureVersion;
     }
 
+    if (this.settings.s3ForcePathStyle) {
+        clientOptions.s3ForcePathStyle = this.settings.s3ForcePathStyle;
+    }
+
     this.client = new AWS.S3(clientOptions);
 
     internals.testBucketAccess(this.client, this.settings, (err, data) => {

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,10 @@ if (process.env.S3_SIGNATURE_VERSION) {
     options.signatureVersion = process.env.S3_SIGNATURE_VERSION;
 }
 
+if (process.env.S3_FORCE_PATH_STYLE) {
+    options.s3ForcePathStyle = process.env.S3_FORCE_PATH_STYLE;
+}
+
 
 // Test shortcuts
 const lab = exports.lab = Lab.script();


### PR DESCRIPTION
## Context

`catbox-s3` supports **virtual-hosted-style** URLs by default. In addition to this option, the AWS SDK also supports  a **path-style** URL.

* virtual-hosted-style: http://bucket.s3.example.com
* path-style: http://s3.example.com/bucket

## Proposal

Allow the user to pass in an option to force path-style URLs for S3 objects

## References

* SDK Config option describing the force `path-style` property
   * https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property