### PR TITLE
feat: Enabling support for EC2 authentication (and others)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Amazon S3 adapter for [catbox](https://github.com/hapijs/catbox).
 ### Options
 
 - `bucket` - the S3 bucket. You need to have write access for it.
-- `accessKeyId` - the Amazon access key.
-- `secretAccessKey` - the Amazon secret access key.
+- `accessKeyId` - the Amazon access key. (If you don't specify key, it will attempt to use local credentials.)
+- `secretAccessKey` - the Amazon secret access key. (If you don't specify secret, it will attempt to use local credentials.)
 - `region` - the Amazon S3 region. (If you don't specify a region, the bucket will be created in US Standard.)
 - `endpoint` - the S3 endpoint URL. (If you don't specify an endpoint, the bucket will be created at Amazon S3 using the provided region if any)
 - `setACL` - defaults to true, if set to false, not ACL is set for the objects

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,8 +84,6 @@ exports = module.exports = internals.Connection = function S3Cache (options) {
 
     Hoek.assert(this.constructor === internals.Connection, 'S3 cache client must be instantiated using new');
     Hoek.assert(options && options.bucket, 'Invalid Amazon S3 bucket value');
-    Hoek.assert(options && options.accessKeyId, 'Invalid Amazon S3 accessKeyId value');
-    Hoek.assert(options && options.secretAccessKey, 'Invalid Amazon S3 secretAccessKey value');
 
     this.settings = Hoek.clone(options || {});
     this.client = null;
@@ -96,10 +94,12 @@ internals.Connection.prototype.start = function (callback) {
 
     const self = this;
 
-    const clientOptions = {
-        accessKeyId     : this.settings.accessKeyId,
-        secretAccessKey : this.settings.secretAccessKey
-    };
+    const clientOptions = {};
+
+    if (this.settings.secretAccessKey && this.settings.accessKeyId) {
+        clientOptions.accessKeyId = this.settings.accessKeyId;
+        clientOptions.secretAccessKey = this.settings.secretAccessKey;
+    }
 
     if (this.settings.region) {
         clientOptions.region = this.settings.region;


### PR DESCRIPTION
By making access key and secret optional, the AWS SDK will default to
looking for credentials in known locations, one of which is EC2
metadata (really useful for EC2/IAM configs).

New order of credential loading:
1. Loaded from AWS Identity and Access Management (IAM) roles for Amazon EC2 (if running on Amazon EC2)
2. Loaded from the shared credentials file (`~/.aws/credentials`)
3. Loaded from environment variables
4. Loaded from a JSON file on disk
5. Loaded from your module's config

More detail [here](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html)