### PR TITLE
feat(54): Support latest version of catbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ var handler = async function (request, h) {
     const result = await cache.get(cacheKey);
 
     if (result) {
-        return h.response(result.item).code(/* response content type */);
+        return h.response(result.item).type(/* response content type */);
     }
 
     const data = await yourBusinessLogic();
 
     await cache.set(cacheKey, data, /* expiration in ms */);
 
-    return h.response(data).code(/* response content type */);
+    return h.response(data).type(/* response content type */);
 };
 
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Amazon S3 adapter for [catbox](https://github.com/hapijs/catbox).
 [![Maintainers Wanted](https://img.shields.io/badge/maintainers-wanted-red.svg)](https://github.com/fhemberger/catbox-s3/issues/56)
 [![Build Status](https://travis-ci.org/fhemberger/catbox-s3.svg?branch=master)](http://travis-ci.org/fhemberger/catbox-s3) ![Current Version](https://img.shields.io/npm/v/catbox-s3.svg)
 
+
 ### Options
 
 - `bucket` - the S3 bucket. You need to have write access for it.
@@ -38,35 +39,31 @@ var cache  = new Catbox.Client(require('catbox-s3'), {
 });
 
 // 2) Inititalize the caching
-cache.start(function (err) {
+cache.start().catch((err) => {
 
     if (err) { console.error(err); }
     /* ... */
 });
 
 // Your route's request handler
-var handler = function (request, reply) {
+var handler = async function (request, h) {
 
     var cacheKey = {
         id      : /* cache item id */,
         segment : /* cache segment name */
     };
 
-    cache.get(cacheKey, function (err, result) {
+    const result = await cache.get(cacheKey);
 
-        if (result) {
-            return reply(result.item).type(/* response content type */);
-        }
+    if (result) {
+        return h.response(result.item).code(/* response content type */);
+    }
 
-        yourBusinessLogic(function (err, data) {
+    const data = await yourBusinessLogic();
 
-            cache.set(cacheKey, data, /* expiration in ms */, function (err) {
+    await cache.set(cacheKey, data, /* expiration in ms */);
 
-                /* ... */
-            });
-            reply(result.item).type(/* response content type */);
-        });
-    });
+    return h.response(data).code(/* response content type */);
 };
 
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,13 +71,13 @@ internals.testBucketAccess = function (client, settings) {
 
         client.putObject(putParams, (err) => {
 
-            if (!err) {
+            if (err) {
                 return reject(new Error(`Error writing to bucket ${settings.bucket} ${err}`));
             }
 
             client.getObject(getParams, (err, data) => {
 
-                if (!err && data.Body.toString('utf8') === 'ok') {
+                if (err || !data.Body.toString('utf8') === 'ok') {
                     return reject(new Error(`Error reading from bucket ${settings.bucket} ${err}`));
                 }
                 resolve();

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,6 @@ internals.parseBody = function (contentType, body) {
 
     if (contentType === 'application/json') {
         /* eslint-disable brace-style */
-        // needs an s3 mock
         try {
             body = JSON.parse(body);
         } catch (e) {}
@@ -59,7 +58,6 @@ internals.testBucketAccess = function (client, settings) {
         Body   : 'ok'
     };
 
-    // needs s3 mock; public-read needs to be nabled
     if (settings.setACL !== false) {
         putParams.ACL = settings.ACL ? settings.ACL : 'public-read';
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ internals.parseBody = function (contentType, body) {
 
     if (contentType === 'application/json') {
         /* eslint-disable brace-style */
+        // needs an s3 mock
         try {
             body = JSON.parse(body);
         } catch (e) {}
@@ -58,6 +59,7 @@ internals.testBucketAccess = function (client, settings) {
         Body   : 'ok'
     };
 
+    // needs s3 mock; public-read needs to be nabled
     if (settings.setACL !== false) {
         putParams.ACL = settings.ACL ? settings.ACL : 'public-read';
     }
@@ -251,6 +253,7 @@ internals.Connection.prototype.set = function (key, value, ttl) {
         };
 
         if (this.settings.setACL !== false) {
+            // TODO
             params.ACL = this.settings.ACL ? this.settings.ACL : 'public-read';
         }
 
@@ -273,6 +276,7 @@ internals.Connection.prototype.set = function (key, value, ttl) {
 
 internals.Connection.prototype.drop = function (key) {
 
+    // this would require mockery and a full mock to test
     return new Promise((resolve, reject) => {
 
         if (!this.isConnected) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -253,7 +253,6 @@ internals.Connection.prototype.set = function (key, value, ttl) {
         };
 
         if (this.settings.setACL !== false) {
-            // TODO
             params.ACL = this.settings.ACL ? this.settings.ACL : 'public-read';
         }
 
@@ -276,7 +275,6 @@ internals.Connection.prototype.set = function (key, value, ttl) {
 
 internals.Connection.prototype.drop = function (key) {
 
-    // this would require mockery and a full mock to test
     return new Promise((resolve, reject) => {
 
         if (!this.isConnected) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ internals.parseBody = function (contentType, body) {
 };
 
 
-internals.testBucketAccess = function (client, settings, callback) {
+internals.testBucketAccess = function (client, settings) {
 
     const putParams = {
         Bucket : settings.bucket,
@@ -67,14 +67,21 @@ internals.testBucketAccess = function (client, settings, callback) {
         Key    : internals.getStoragePathForKey({ segment: 'catbox-s3', id: 'accesstest' })
     };
 
-    client.putObject(putParams, (err) => {
+    return new Promise((resolve, reject) => {
 
-        Hoek.assert(!err, `Error writing to bucket ${settings.bucket} ${err}`);
+        client.putObject(putParams, (err) => {
 
-        client.getObject(getParams, (err, data) => {
+            if (!err) {
+                return reject(new Error(`Error writing to bucket ${settings.bucket} ${err}`));
+            }
 
-            Hoek.assert(!err && data.Body.toString('utf8') === 'ok', `Error reading from bucket ${settings.bucket} ${err}`);
-            callback();
+            client.getObject(getParams, (err, data) => {
+
+                if (!err && data.Body.toString('utf8') === 'ok') {
+                    return reject(new Error(`Error reading from bucket ${settings.bucket} ${err}`));
+                }
+                resolve();
+            });
         });
     });
 };
@@ -90,7 +97,7 @@ exports = module.exports = internals.Connection = function S3Cache (options) {
 };
 
 
-internals.Connection.prototype.start = function (callback) {
+internals.Connection.prototype.start = function () {
 
     const self = this;
 
@@ -119,16 +126,17 @@ internals.Connection.prototype.start = function (callback) {
 
     this.client = new AWS.S3(clientOptions);
 
-    internals.testBucketAccess(this.client, this.settings, (err, data) => {
+    return internals.testBucketAccess(this.client, this.settings)
+        .then((data) => {
 
-        if (err) {
+            self.isConnected = true;
+        })
+        .catch((err) => {
+
             self.isConnected = false;
-            return callback(err);
-        }
 
-        self.isConnected = true;
-        callback();
-    });
+            throw err;
+        });
 };
 
 
@@ -165,115 +173,123 @@ internals.Connection.prototype.validateSegmentName = function (name) {
 };
 
 
-internals.Connection.prototype.get = function (key, callback) {
+internals.Connection.prototype.get = function (key) {
 
-    if (!this.isConnected) {
-        return callback(new Error('Connection not started'));
-    }
+    return new Promise((resolve, reject) => {
 
-    const params = {
-        Bucket : this.settings.bucket,
-        Key    : internals.getStoragePathForKey(key)
-    };
-
-    this.client.getObject(params, (err, data) => {
-
-        if (err) {
-            return callback(null, null);
+        if (!this.isConnected) {
+            return reject(new Error('Connection not started'));
         }
 
-        const now    = new Date().getTime();
-        const stored = new Date(data.Metadata['catbox-stored']);
-        let ttl      = Number(data.Metadata['catbox-ttl']) || 0;
-
-        // Calculate remaining ttl
-        ttl = (stored.getTime() + ttl) - now;
-
-        // Cache item has expired
-        if (ttl <= 0) {
-            return callback(null, null);
-        }
-
-        const result = {
-            item: internals.parseBody(data.ContentType, data.Body),
-            stored,
-            ttl
+        const params = {
+            Bucket : this.settings.bucket,
+            Key    : internals.getStoragePathForKey(key)
         };
 
-        callback(null, result);
+        this.client.getObject(params, (err, data) => {
 
+            if (err) {
+                return resolve(null);
+            }
+
+            const now    = new Date().getTime();
+            const stored = new Date(data.Metadata['catbox-stored']);
+            let ttl      = Number(data.Metadata['catbox-ttl']) || 0;
+
+            // Calculate remaining ttl
+            ttl = (stored.getTime() + ttl) - now;
+
+            // Cache item has expired
+            if (ttl <= 0) {
+                return resolve(null);
+            }
+
+            const result = {
+                item: internals.parseBody(data.ContentType, data.Body),
+                stored,
+                ttl
+            };
+
+            resolve(result);
+        });
     });
 };
 
 
-internals.Connection.prototype.set = function (key, value, ttl, callback) {
+internals.Connection.prototype.set = function (key, value, ttl) {
 
-    if (!this.isConnected) {
-        return callback(new Error('Connection not started'));
-    }
+    return new Promise((resolve, reject) => {
 
-    let type = 'application/octet-stream';
-
-    if (['String', 'Number', 'Boolean'].indexOf(value.constructor.name) > -1) {
-        type = 'text/plain';
-    }
-
-    if (['Object', 'Array'].indexOf(value.constructor.name) > -1) {
-        /* eslint-disable brace-style */
-        try {
-            value = JSON.stringify(value);
-            type = 'application/json';
-        } catch (e) {
-            return callback(new Error('Could not convert object to JSON'));
+        if (!this.isConnected) {
+            return reject(new Error('Connection not started'));
         }
-        /* eslint-enable brace-style */
-    }
 
-    const now = new Date();
-    const params = {
-        Bucket      : this.settings.bucket,
-        Key         : internals.getStoragePathForKey(key),
-        Expires     : new Date(now.getTime() + ttl),
-        ContentType : type,
-        Body        : value
-    };
+        let type = 'application/octet-stream';
 
-    if (this.settings.setACL !== false) {
-        params.ACL = this.settings.ACL ? this.settings.ACL : 'public-read';
-    }
-
-    const req = this.client.putObject(params);
-    req.on('build', () => {
-
-        req.httpRequest.headers['x-amz-meta-catbox-stored'] = now;
-        req.httpRequest.headers['x-amz-meta-catbox-ttl']    = ttl;
-    });
-    req.send((err) => {
-
-        if (err) {
-            return callback(err);
+        if (['String', 'Number', 'Boolean'].indexOf(value.constructor.name) > -1) {
+            type = 'text/plain';
         }
-        callback();
+
+        if (['Object', 'Array'].indexOf(value.constructor.name) > -1) {
+            /* eslint-disable brace-style */
+            try {
+                value = JSON.stringify(value);
+                type = 'application/json';
+            } catch (e) {
+                return reject(new Error('Could not convert object to JSON'));
+            }
+            /* eslint-enable brace-style */
+        }
+
+        const now = new Date();
+        const params = {
+            Bucket      : this.settings.bucket,
+            Key         : internals.getStoragePathForKey(key),
+            Expires     : new Date(now.getTime() + ttl),
+            ContentType : type,
+            Body        : value
+        };
+
+        if (this.settings.setACL !== false) {
+            params.ACL = this.settings.ACL ? this.settings.ACL : 'public-read';
+        }
+
+        const req = this.client.putObject(params);
+        req.on('build', () => {
+
+            req.httpRequest.headers['x-amz-meta-catbox-stored'] = now;
+            req.httpRequest.headers['x-amz-meta-catbox-ttl']    = ttl;
+        });
+        req.send((err) => {
+
+            if (err) {
+                return reject(err);
+            }
+            resolve();
+        });
     });
 };
 
 
-internals.Connection.prototype.drop = function (key, callback) {
+internals.Connection.prototype.drop = function (key) {
 
-    if (!this.isConnected) {
-        return callback(new Error('Connection not started'));
-    }
+    return new Promise((resolve, reject) => {
 
-    const params = {
-        Bucket : this.settings.bucket,
-        Key    : internals.getStoragePathForKey(key)
-    };
-
-    this.client.deleteObject(params, (err) => {
-
-        if (err) {
-            return callback(err);
+        if (!this.isConnected) {
+            return reject(new Error('Connection not started'));
         }
-        callback();
+
+        const params = {
+            Bucket : this.settings.bucket,
+            Key    : internals.getStoragePathForKey(key)
+        };
+
+        this.client.deleteObject(params, (err) => {
+
+            if (err) {
+                return reject(err);
+            }
+            resolve();
+        });
     });
 };

--- a/package.json
+++ b/package.json
@@ -31,17 +31,17 @@
   },
   "homepage": "https://github.com/fhemberger/catbox-s3",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.9.0"
   },
   "dependencies": {
     "aws-sdk": "^2.196.0",
     "hoek": "5.0.3"
   },
   "devDependencies": {
-    "catbox": "7.x.x",
-    "code": "4.x.x",
-    "eslint-config-hapi": "10.x.x",
+    "catbox": "10.x.x",
+    "code": "5.x.x",
+    "eslint-config-hapi": "11.x.x",
     "eslint-plugin-hapi": "4.x.x",
-    "lab": "12.x.x"
+    "lab": "15.x.x"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -224,6 +224,15 @@ describe('S3', () => {
         await expect(client.get(key)).to.reject();
     });
 
+    it('errors on set when stopped', async () => {
+
+        const client = new Catbox.Client(S3, options);
+        client.stop();
+        const key = { id: 'x', segment: 'test' };
+
+        await expect(client.connection.set(key, 'y', 1)).to.reject();
+    });
+
 
     it('errors on missing segment name', () => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -118,7 +118,7 @@ describe('S3', () => {
         const value = { a: 1 };
         value.b = value;
 
-        await expect(client.set(key, value, 10)).to.reject(new Error('Could not convert to JSON'));
+        await expect(client.set(key, value, 10)).to.reject(Error, 'Could not convert object to JSON');
     });
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,7 @@ const expect = Code.expect;
 
 describe('S3', () => {
 
-    it('throws an error if not created with new', (done) => {
+    it('throws an error if not created with new', () => {
 
         const fn = () => {
 
@@ -48,138 +48,87 @@ describe('S3', () => {
         };
 
         expect(fn).to.throw(Error);
-        done();
     });
 
-
-    it('creates a new connection', (done) => {
+    it('creates a new connection', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
-
-            expect(err).to.not.exist();
-            expect(client.isReady()).to.equal(true);
-            done();
-        });
+        await client.start()
+        expect(client.isReady()).to.equal(true);
     });
 
-    it('closes the connection', (done) => {
+    it('closes the connection', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
-
-            expect(err).to.not.exist();
-            expect(client.isReady()).to.equal(true);
-            client.stop();
-            expect(client.isReady()).to.equal(false);
-            done();
-        });
+        await client.start();
+        expect(client.isReady()).to.equal(true);
+        client.stop();
+        expect(client.isReady()).to.equal(false);
     });
 
 
-    it('gets an item after setting it', (done) => {
+    it('gets an item after setting it', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
+        await client.start();
 
-            expect(err).to.not.exist();
-            const key = { id: 'test/id?with special%chars&', segment: 'test' };
-            client.set(key, '123', 5000, (err) => {
+        const key = { id: 'test/id?with special%chars&', segment: 'test' };
+        await client.set(key, '123', 5000);
+        const result = await client.get(key);
 
-                expect(err).to.not.exist();
-                client.get(key, (err, result) => {
-
-                    expect(err).to.equal(null);
-                    expect(result.item).to.equal('123');
-                    done();
-                });
-            });
-        });
+        expect(result.item).to.equal('123');
     });
 
 
-    it('buffers can be set and retrieved', (done) => {
+    it('buffers can be set and retrieved', async () => {
 
         const buffer = new Buffer('string value');
         const client = new Catbox.Client(new S3(options));
+        await client.start();
 
-        client.start((err) => {
+        const key = { id: 'buffer', segment: 'test' };
+        await client.set(key, buffer, 2000);
+        const result = await client.get(key);
 
-            expect(err).to.not.exist();
-            const key = { id: 'buffer', segment: 'test' };
-
-            client.set(key, buffer, 2000, (err) => {
-
-                expect(err).to.not.exist();
-                client.get(key, (err, result) => {
-
-                    expect(err).to.not.exist();
-                    expect(result.item instanceof Buffer).to.equal(true);
-                    expect(result.item).to.equal(buffer);
-                    done();
-                });
-            });
-        });
+        expect(result.item instanceof Buffer).to.equal(true);
+        expect(result.item).to.equal(buffer);
     });
 
 
-    it('buffers are copied before storing', (done) => {
+    it('buffers are copied before storing', async () => {
 
         const buffer = new Buffer('string value');
         const client = new Catbox.Client(new S3(options));
+        await client.start();
 
-        client.start((err) => {
+        const key = { id: 'buffer-copied', segment: 'test' };
+        await client.set(key, buffer, 2000);
+        const result = await client.get(key);
 
-            expect(err).to.not.exist();
-            const key = { id: 'buffer-copied', segment: 'test' };
-            client.set(key, buffer, 2000, (err) => {
-
-                expect(err).to.not.exist();
-                client.get(key, (err, result) => {
-
-                    expect(err).to.not.exist();
-                    expect(result.item).to.not.shallow.equal(buffer);
-                    done();
-                });
-            });
-        });
+        expect(result.item).to.not.shallow.equal(buffer);
     });
 
 
-    it('fails setting an item circular references', (done) => {
+    it('fails setting an item circular references', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
+        await client.start();
 
-            expect(err).to.not.exist();
-            const key = { id: 'circular', segment: 'test' };
-            const value = { a: 1 };
-            value.b = value;
+        const key = { id: 'circular', segment: 'test' };
+        const value = { a: 1 };
+        value.b = value;
 
-            client.set(key, value, 10, (err) => {
-
-                expect(err.message).to.equal('Could not convert object to JSON');
-                done();
-            });
-        });
+        await expect(client.set(key, value, 10)).to.reject(new Error('Could not convert to JSON'));
     });
 
 
-    it('ignored starting a connection twice on same event', (done) => {
+    it('ignored starting a connection twice on same event', () => {
 
-        let x = 2;
         const client = new Catbox.Client(S3, options);
-        const start = () => {
+        const start = async function () {
 
-            client.start((err) => {
-
-                expect(err).to.not.exist();
-                expect(client.isReady()).to.equal(true);
-                --x;
-                if (!x) {
-                    done();
-                }
-            });
+            await client.start();
+            expect(client.isReady()).to.equal(true);
         };
 
         start();
@@ -187,152 +136,96 @@ describe('S3', () => {
     });
 
 
-    it('ignored starting a connection twice chained', (done) => {
+    it('ignored starting a connection twice chained', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
+        await client.start();
+        expect(client.isReady()).to.equal(true);
 
-            expect(err).to.not.exist();
-            expect(client.isReady()).to.equal(true);
-            client.start((err) => {
-
-                expect(err).to.not.exist();
-                expect(client.isReady()).to.equal(true);
-                done();
-            });
-        });
+        await client.start();
+        expect(client.isReady()).to.equal(true);
     });
 
 
-    it('returns not found on get when using null key', (done) => {
+    it('returns not found on get when using null key', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
+        await client.start();
 
-            expect(err).to.not.exist();
-            client.get(null, (err, result) => {
+        const result = await client.get(null);
 
-                expect(err).to.equal(null);
+        expect(result).to.equal(null);
+    });
+
+
+    it('returns not found on get when item expired', async () => {
+
+        const client = new Catbox.Client(S3, options);
+        await client.start();
+
+        const key = { id: 'x', segment: 'test' };
+
+        await client.set(key, 'x', 1);
+        await new Promise((resolve) => {
+
+            setTimeout(async () => {
+
+                const result = await client.get(key);
                 expect(result).to.equal(null);
-                done();
-            });
+                resolve();
+            }, 2);
         });
     });
 
 
-    it('returns not found on get when item expired', (done) => {
+    it('errors on set when using null key', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
+        await client.start();
 
-            expect(err).to.not.exist();
-            const key = { id: 'x', segment: 'test' };
-            client.set(key, 'x', 1, (err) => {
-
-                expect(err).to.not.exist();
-                setTimeout(() => {
-
-                    client.get(key, (err, result) => {
-
-                        expect(err).to.equal(null);
-                        expect(result).to.equal(null);
-                        done();
-                    });
-                }, 1000);
-            });
-        });
+        await expect(client.set(null, {}, 1000)).to.reject();
     });
 
 
-    it('errors on set when using null key', (done) => {
+    it('errors on get when using invalid key', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
+        await client.start();
 
-            expect(err).to.not.exist();
-            client.set(null, {}, 1000, (err) => {
-
-                expect(err instanceof Error).to.equal(true);
-                done();
-            });
-        });
+        await expect(client.get({})).to.reject();
     });
 
 
-    it('errors on get when using invalid key', (done) => {
+    it('errors on set when using invalid key', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
+        await client.start();
 
-            expect(err).to.not.exist();
-            client.get({}, (err) => {
-
-                expect(err instanceof Error).to.equal(true);
-                done();
-            });
-        });
+        await expect(client.set({}, {}, 1000)).to.reject();
     });
 
 
-    it('errors on set when using invalid key', (done) => {
+    it('ignores set when using non-positive ttl value', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
+        await client.start();
 
-            expect(err).to.not.exist();
-            client.set({}, {}, 1000, (err) => {
-
-                expect(err instanceof Error).to.equal(true);
-                done();
-            });
-        });
+        const key = { id: 'x', segment: 'test' };
+        await client.set(key, 'y', 0);
     });
 
 
-    it('ignores set when using non-positive ttl value', (done) => {
-
-        const client = new Catbox.Client(S3, options);
-        client.start((err) => {
-
-            expect(err).to.not.exist();
-            const key = { id: 'x', segment: 'test' };
-            client.set(key, 'y', 0, (err) => {
-
-                expect(err).to.not.exist();
-                done();
-            });
-        });
-    });
-
-
-    it('errors on get when stopped', (done) => {
+    it('returns error on get when stopped', async () => {
 
         const client = new Catbox.Client(S3, options);
         client.stop();
         const key = { id: 'x', segment: 'test' };
-        client.connection.get(key, (err, result) => {
 
-            expect(err).to.exist;
-            expect(result).to.not.exist;
-            done();
-        });
+        await expect(client.get(key)).to.reject();
     });
 
 
-    it('errors on set when stopped', (done) => {
-
-        const client = new Catbox.Client(S3, options);
-        client.stop();
-        const key = { id: 'x', segment: 'test' };
-        client.connection.set(key, 'y', 1, (err) => {
-
-            expect(err).to.exist;
-            done();
-        });
-    });
-
-
-    it('errors on missing segment name', (done) => {
+    it('errors on missing segment name', () => {
 
         const config = {
             expiresIn: 50000
@@ -343,83 +236,70 @@ describe('S3', () => {
             const client = new Catbox.Client(S3, options);
             new Catbox.Policy(config, client, '');
         };
+
         expect(fn).to.throw(Error);
-        done();
     });
 
 
-    it('errors on bad segment name', (done) => {
+    it('errors on bad segment name', () => {
 
         const config = {
             expiresIn: 50000
         };
+
         const fn = () => {
 
             const client = new Catbox.Client(S3, options);
             new Catbox.Policy(config, client, 'a\0b');
         };
+
         expect(fn).to.throw(Error);
-        done();
     });
 
 
-    it('supports empty keys', (done) => {
+    it('supports empty keys', async () => {
 
         const client = new Catbox.Client(S3, options);
-        client.start((err) => {
+        await client.start();
 
-            expect(err).to.not.exist();
+        const key = { id: '', segment: 'test' };
+        await client.set(key, '123', 5000);
+        const result = await client.get(key);
 
-            const key = { id: '', segment: 'test' };
-            client.set(key, '123', 5000, (err) => {
-
-                expect(err).to.not.exist();
-                client.get(key, (err, result) => {
-
-                    expect(err).to.not.exist();
-                    expect(result.item).to.equal('123');
-                    done();
-                });
-            });
-        });
+        expect(result.item).to.equal('123');
     });
 
 
     describe('#start', () => {
 
-        it('creates an empty client object', (done) => {
+        it('creates an empty client object', async () => {
 
             const s3 = new S3(options);
             expect(s3.client).to.not.exist;
-            s3.start(() => {
 
-                expect(s3.client).to.exist;
-                done();
-            });
+            await s3.start();
+            expect(s3.client).to.exist;
         });
-
     });
 
     describe('#stop', () => {
 
-        it('sets the cache client to null', (done) => {
+        it('sets the cache client to null', async () => {
 
             const s3 = new S3(options);
             expect(s3.client).to.not.exist;
-            s3.start(() => {
 
-                expect(s3.client).to.exist;
-                s3.stop();
-                expect(s3.client).to.not.exist;
-                done();
-            });
+            await s3.start();
+            expect(s3.client).to.exist;
+            s3.stop();
+            expect(s3.client).to.not.exist;
         });
 
     });
 
     describe('#get', () => {
 
-        it('returns not found on missing segment', (done) => {
+        it('returns not found on missing segment', async () => {
 
             const key = {
                 segment : 'unknownsegment',
@@ -427,256 +307,183 @@ describe('S3', () => {
             };
             const s3 = new S3(options);
             expect(s3.client).to.not.exist;
-            s3.start(() => {
 
-                expect(s3.client).to.exist;
-                s3.get(key, (err, result) => {
+            await s3.start();
+            expect(s3.client).to.exist;
+            const result = await s3.get(key);
 
-                    expect(err).to.not.exist();
-                    expect(result).to.not.exist;
-                    done();
-                });
-            });
+            expect(result).to.not.exist;
         });
     });
 
 
     describe('#set', () => {
 
-        it('adds an item to the cache object', (done) => {
+        it('adds an item to the cache object', async () => {
 
             const key = {
                 segment : 'test',
                 id      : 'test'
             };
-
             const s3 = new S3(options);
             expect(s3.client).to.not.exist;
 
-            s3.start(() => {
+            await s3.start();
+            expect(s3.client).to.exist;
+            await s3.set(key, 'myvalue', 2000);
+            const result = await s3.get(key);
 
-                expect(s3.client).to.exist;
-                s3.set(key, 'myvalue', 2000, () => {
-
-                    s3.get(key, (err, result) => {
-
-                        expect(err).to.not.exist();
-                        expect(result.item).to.equal('myvalue');
-                        done();
-                    });
-                });
-            });
+            expect(result.item).to.equal('myvalue');
         });
 
-        it('removes an item from the cache object when it expires', (done) => {
+        it('removes an item from the cache object when it expires', async () => {
 
             const key = {
                 segment: 'test',
                 id: 'test'
             };
-
             const s3 = new S3(options);
             expect(s3.client).to.not.exist;
-            s3.start(() => {
 
-                expect(s3.client).to.exist;
-                s3.set(key, 'myvalue', 2000, () => {
+            await s3.start();
+            expect(s3.client).to.exist;
+            await s3.set(key, 'myvalue', 2000);
+            const result = await s3.get(key);
 
-                    s3.get(key, (err, result) => {
+            expect(result.item).to.equal('myvalue');
+            setTimeout(async () => {
 
-                        expect(err).to.not.exist();
-                        expect(result.item).to.equal('myvalue');
-                        setTimeout(() => {
-
-                            s3.get(key, (err, result) => {
-
-                                expect(err).to.not.exist();
-                                expect(result).to.not.exist;
-                                done();
-                            });
-                        }, 1500);
-                    });
-                });
-            });
+                const result = await s3.get(key);
+                expect(result).to.not.exist;
+            }, 1500);
         });
     });
 
 
     describe('#drop', () => {
 
-        it('drops an existing item', (done) => {
+        it('drops an existing item', async () => {
 
             const client = new Catbox.Client(S3, options);
-            client.start((err) => {
+            await client.start();
 
-                expect(err).to.not.exist();
-                const key = { id: 'x', segment: 'test' };
-                client.set(key, '123', 5000, (err) => {
+            const key = { id: 'x', segment: 'test' };
+            await client.set(key, '123', 5000);
+            const result = await client.get(key);
 
-                    expect(err).to.not.exist();
-                    client.get(key, (err, result) => {
-
-                        expect(err).to.equal(null);
-                        expect(result.item).to.equal('123');
-                        client.drop(key, (err) => {
-
-                            expect(err).to.not.exist();
-                            done();
-                        });
-                    });
-                });
-            });
+            expect(result.item).to.equal('123');
+            await client.drop(key);
         });
 
 
-        it('drops an item from a missing segment', (done) => {
+        it('drops an item from a missing segment', async () => {
 
             const client = new Catbox.Client(S3, options);
-            client.start((err) => {
+            await client.start();
 
-                expect(err).to.not.exist();
-                const key = { id: 'x', segment: 'test' };
-                client.drop(key, (err) => {
-
-                    expect(err).to.not.exist();
-                    done();
-                });
-            });
+            const key = { id: 'x', segment: 'test' };
+            await client.drop(key);
         });
 
 
-        it('drops a missing item', (done) => {
+        it('drops a missing item', async () => {
 
             const client = new Catbox.Client(S3, options);
-            client.start((err) => {
+            await client.start();
 
-                expect(err).to.not.exist();
-                const key = { id: 'x', segment: 'test' };
-                client.set(key, '123', 2000, (err) => {
+            const key = { id: 'x', segment: 'test' };
+            await client.set(key, '123', 2000);
+            const result = await client.get(key);
 
-                    expect(err).to.not.exist();
-                    client.get(key, (err, result) => {
-
-                        expect(err).to.equal(null);
-                        expect(result.item).to.equal('123');
-                        client.drop({ id: 'y', segment: 'test' }, (err) => {
-
-                            expect(err).to.not.exist();
-                            done();
-                        });
-                    });
-                });
-            });
+            expect(result.item).to.equal('123');
+            await client.drop({ id: 'y', segment: 'test' });
         });
 
 
-        it('errors on drop when using invalid key', (done) => {
+        it('errors on drop when using invalid key', async () => {
 
             const client = new Catbox.Client(S3, options);
-            client.start((err) => {
+            await client.start();
 
-                expect(err).to.not.exist();
-                client.drop({}, (err) => {
-
-                    expect(err instanceof Error).to.equal(true);
-                    done();
-                });
-            });
+            expect(client.drop({})).to.reject();
         });
 
 
-        it('errors on drop when using null key', (done) => {
+        it('errors on drop when using null key', async () => {
 
             const client = new Catbox.Client(S3, options);
-            client.start((err) => {
+            await client.start();
 
-                expect(err).to.not.exist();
-                client.drop(null, (err) => {
-
-                    expect(err instanceof Error).to.equal(true);
-                    done();
-                });
-            });
+            expect(client.drop(null)).to.reject();
         });
 
 
-        it('errors on drop when stopped', (done) => {
+        it('errors on drop when stopped', async () => {
 
             const client = new Catbox.Client(S3, options);
             client.stop();
             const key = { id: 'x', segment: 'test' };
-            client.connection.drop(key, (err) => {
 
-                expect(err).to.exist;
-                done();
-            });
+            expect(client.connection.drop(key)).to.reject();
         });
 
 
-        it('errors when cache item dropped while stopped', (done) => {
+        it('errors when cache item dropped while stopped', async () => {
 
             const client = new Catbox.Client(S3, options);
             client.stop();
-            client.drop('a', (err) => {
 
-                expect(err).to.exist;
-                done();
-            });
+            expect(client.connection.drop('a')).to.reject();
         });
     });
 
 
     describe('#validateSegmentName', () => {
 
-        it('errors when the name is empty', (done) => {
+        it('errors when the name is empty', () => {
 
             const s3 = new S3(options);
             const result = s3.validateSegmentName('');
 
             expect(result).to.be.instanceOf(Error);
             expect(result.message).to.equal('Empty string');
-            done();
         });
 
 
-        it('errors when the name has a null character', (done) => {
+        it('errors when the name has a null character', () => {
 
             const s3 = new S3(options);
             const result = s3.validateSegmentName('\0test');
 
             expect(result).to.be.instanceOf(Error);
-            done();
         });
 
 
-        it('errors when the name has less than three characters', (done) => {
+        it('errors when the name has less than three characters', () => {
 
             const s3 = new S3(options);
             const result = s3.validateSegmentName('yo');
 
             expect(result).to.be.instanceOf(Error);
-            done();
         });
 
 
-        it('errors when the name has more than 64 characters', (done) => {
+        it('errors when the name has more than 64 characters', () => {
 
             const s3 = new S3(options);
             const result = s3.validateSegmentName('abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890');
 
             expect(result).to.be.instanceOf(Error);
-            done();
         });
 
 
-        it('returns null when there are no errors', (done) => {
+        it('returns null when there are no errors', () => {
 
             const s3 = new S3(options);
             const result = s3.validateSegmentName('valid');
 
             expect(result).to.not.be.instanceOf(Error);
             expect(result).to.equal(null);
-            done();
         });
     });
 });


### PR DESCRIPTION
## Context

The latest version of catbox does not support the callback pattern, and expects functions to return promises instead.

## Objective

* Replace callbacks with promises (ie. functions that were passed a callback now return a promise)

## References

* Issue: https://github.com/fhemberger/catbox-s3/issues/54