### PR TITLE
feat: Pass md5 of contents in metadata during set()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
 // Load modules
-const Hoek = require('hoek');
-const AWS  = require('aws-sdk');
+const Hoek   = require('hoek');
+const AWS    = require('aws-sdk');
+const crypto = require('crypto');
 
 
 // Declare internals
@@ -215,7 +216,6 @@ internals.Connection.prototype.get = function (key) {
     });
 };
 
-
 internals.Connection.prototype.set = function (key, value, ttl) {
 
     return new Promise((resolve, reject) => {
@@ -242,6 +242,7 @@ internals.Connection.prototype.set = function (key, value, ttl) {
         }
 
         const now = new Date();
+        const md5 = crypto.createHash('md5').update(value).digest('hex');
         const params = {
             Bucket      : this.settings.bucket,
             Key         : internals.getStoragePathForKey(key),
@@ -259,6 +260,7 @@ internals.Connection.prototype.set = function (key, value, ttl) {
 
             req.httpRequest.headers['x-amz-meta-catbox-stored'] = now;
             req.httpRequest.headers['x-amz-meta-catbox-ttl']    = ttl;
+            req.httpRequest.headers['x-amz-meta-md5']           = md5;
         });
         req.send((err) => {
 


### PR DESCRIPTION
This would be useful when trying to set() on the same key again (If md5 of local file and remote file are the same, don't set())